### PR TITLE
NXP-28350: fix labels for unresolved directory entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bin
 **/js/app/app-build.js
 **/node_modules/
 **/bower_components/
+**/*.map

--- a/nuxeo-platform-spreadsheet-web/src/main/js/app/ui/spreadsheet.js
+++ b/nuxeo-platform-spreadsheet-web/src/main/js/app/ui/spreadsheet.js
@@ -311,7 +311,8 @@ class Spreadsheet {
         var dataEntry = data[dataRowIndex][dataColIndex];
         var formattedLabel = editor.formatter(dataEntry);
         if (!formattedLabel) {
-          var id = editor.getEntryId(dataEntry) || dataEntry.properties && dataEntry.properties.id;
+          // resolved || unresolved (when just filled in)
+          var id = (dataEntry.properties && dataEntry.properties.id) || dataEntry;
           var cell = ht.getCellMeta(i, j);
           if (!cell._labels) {
             cell._labels = {};

--- a/nuxeo-platform-spreadsheet-web/src/main/js/gulpfile.js
+++ b/nuxeo-platform-spreadsheet-web/src/main/js/gulpfile.js
@@ -17,7 +17,7 @@ gulp.task('transpile', function () {
   var traceur = path.join('node_modules', 'traceur', 'traceur'),
       out = path.join('app', 'app-build.js');
   return gulp.src('app/app.js', {read:false})
-    .pipe($.shell(['node ' + traceur + ' --modules=instantiate --experimental --out '+ out + ' <%= file.path %>']));
+    .pipe($.shell(['node ' + traceur + ' --modules=instantiate --source-maps --experimental --out '+ out + ' <%= file.path %>']));
 });
 
 gulp.task('jshint', function () {


### PR DESCRIPTION
At this stage we're never working with directory suggestion entries, so `dataEntry` is either a resolved field or a plain string.
Took the opportunity to enable source maps for a much nicer dev experience.